### PR TITLE
header-link click fix

### DIFF
--- a/src/components/Appbar/index.tsx
+++ b/src/components/Appbar/index.tsx
@@ -58,13 +58,15 @@ const Appbar = ({ setPrefersDarkMode }: AppbarProps) => {
   const queryClient = useQueryClient();
   const dispatch = useDispatch<AppDispatch>();
 
-  const handleClick = () => history.push(Routes.ROOT);
-
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const [isSidebarOpen, setSidebarOpen] = useState(false);
 
   const isUserLogged = useMemo(() => !!user, [user]);
   const prefersDarkMode = useMemo(() => theme.palette.mode === "dark", [theme]);
+
+  const handleClick = () => {
+    return isUserLogged === true ? history.push(Routes.PRODUCT): history.push(Routes.ROOT)
+  }
 
   const handleMenu = useCallback((event: React.MouseEvent<HTMLElement>) => {
     setAnchorEl(event.currentTarget);

--- a/src/components/ProductCard/index.tsx
+++ b/src/components/ProductCard/index.tsx
@@ -48,7 +48,7 @@ const ProductCard = (props: ProductCardProps) => {
         <CardMedia
           component="img"
           alt="product image"
-          height="200"
+          height="120"
           image={product.image}
         />
         <CardContent>

--- a/src/components/ProductCard/index.tsx
+++ b/src/components/ProductCard/index.tsx
@@ -48,7 +48,7 @@ const ProductCard = (props: ProductCardProps) => {
         <CardMedia
           component="img"
           alt="product image"
-          height="120"
+          height="200"
           image={product.image}
         />
         <CardContent>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3512,9 +3512,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001125, caniuse-lite@^1.0.30001280:
-  version "1.0.30001285"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001285.tgz#fe1e52229187e11d6670590790d669b9e03315b7"
-  integrity sha512-KAOkuUtcQ901MtmvxfKD+ODHH9YVDYnBt+TGYSz2KIfnq22CiArbUxXPN9067gNbgMlnNYRSwho8OPXZPALB9Q==
+  version "1.0.30001518"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001518.tgz"
+  integrity sha512-rup09/e3I0BKjncL+FesTayKtPrdwKhUufQFd3riFw1hHg8JmIFoInYfB102cFcY/pPgGmdyl/iy+jgiDi2vdA==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Clicking on header-link now redirects to Routes.PRODUCT instead of Routers.ROOT if user is logged in.